### PR TITLE
Add flag for target directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Usage
 Flags
 
     -n=100: Iterations to test - default 100
+    -dir=/tmp: Target directory - default os.TmpDir()
 
 It will produce output like this
 
@@ -55,3 +56,4 @@ Contributors
 ------------
 
 - Your name goes here!
+- Matteo Olivi <matteoolivi7@gmail.com>

--- a/fsyncbench.go
+++ b/fsyncbench.go
@@ -9,11 +9,14 @@ import (
 	"time"
 )
 
-var pN = flag.Int("n", 100, "Iterations to test - default 100")
+var (
+	pN  = flag.Int("n", 100, "Iterations to test - default 100")
+	dir = flag.String("dir", "", "Target directory - default os.TmpDir()")
+)
 
 func main() {
 	flag.Parse()
-	out, err := ioutil.TempFile("", "fsyncbench")
+	out, err := ioutil.TempFile(*dir, "fsyncbench")
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
### What does this PR do?
Adds a flag that allows the user to specify the directory where the file fsync() is invoked upon is created.

### Why is it useful?
Different physical devices might be mounted at different locations. If one wants to benchmark fsync against a specific device, he/she must be able to specify the directory where the file fsync() is invoked upon is created, to make sure it's on the intended device. 